### PR TITLE
Updated for Lift 3 and Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++test ++package
+  - sbt +test +package
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ jdk:
 script:
   - sbt +test +package
 
+after_success:
+  - ./travis-publish.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+
+jdk:
+  - oraclejdk8
+
+script:
+  - sbt ++test ++package
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: scala
-
 jdk:
-  - oraclejdk8
-
+- oraclejdk8
+cache:
+  directories:
+  - "$HOME/.ivy2/cache"
+  - "$HOME/.sbt"
 script:
-  - sbt +test +package
-
+- sbt +test +package
 after_success:
-  - ./travis-publish.sh
-
+- "./travis-publish.sh"
+env:
+  global:
+  - secure: CoCzY6yYGP1pE7qrYMm9/N2xfbsqH7ZCGNldu//neYTiY92MTgwn/Z+tEPvgw/6fYcHIEgwIY9O5/DgLSLkFR31/FZQsmS9+SyjTs9St/3+XVfeJ4l+VyUe2jSxZx9uaNHaJmYYukKIpEf0X01cXmCxQjXQoKYubiI8HKkewzeQ=
+  - secure: GAkLcCAFWF2o5YLyWaOoP44iOF/9hLHFRm571RgmLoyQkBXSw7Osfv1znw3srGwfOKiM7PH9T4Eais+iTgOQdrfNXRtM4CvaD4797TZIHaqz+HMqXl1MJVJ2iS/K+K2RhJbSQU06yTG6Ks+lF+FK63nhXSFdgPy7T64FsVBd818=

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Notes for module developers
 Learn more about modules on the [Lift Wiki page for modules](https://www.assembla.com/spaces/liftweb/wiki/Modules).
 
 Travis hosts the [project build](https://travis-ci.org/liftmodules/amqp/).
+SNAPSHOT versions are automatically published to Sonatype when merged to master.
 
 This project compiles for Lift 3 by default.
 To build for other versions of Lift, change the value of `liftVersion` in SBT.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Notes for module developers
 
 Learn more about modules on the [Lift Wiki page for modules](https://www.assembla.com/spaces/liftweb/wiki/Modules).
 
+Travis hosts the [project build](https://travis-ci.org/liftmodules/amqp/).
+
 This project compiles for Lift 3 by default.
 To build for other versions of Lift, change the value of `liftVersion` in SBT.
 For example:

--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@ This module provides integration with the [Advanced Message Queuing Protocol (AM
 Quick start for users
 =====================
 
-
 To include this module in your Lift project, update your `libraryDependencies` in `build.sbt` to include:
+
+*Lift 2.6.x* for Scala 2.11:
+
+    "net.liftmodules" %% "amqp_2.6" % "1.4.0"
 
 *Lift 2.6.x* for Scala 2.9 and 2.10:
 
     "net.liftmodules" %% "amqp_2.6" % "1.3"
-
-*Lift 2.6.x* for Scala 2.11:
-
-	 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-	 	 
-    "net.liftmodules" %% "amqp_2.6" % "1.4-SNAPSHOT"
 
 *Lift 2.5.x* for Scala 2.9 and 2.10:
 
@@ -42,6 +39,15 @@ Documentation
 Notes for module developers
 ===========================
 
-* The [Jenkins build](https://liftmodules.ci.cloudbees.com/job/amqp/) is triggered on a push to master.
-
 Learn more about modules on the [Lift Wiki page for modules](https://www.assembla.com/spaces/liftweb/wiki/Modules).
+
+This project compiles for Lift 3 by default.
+To build for other versions of Lift, change the value of `liftVersion` in SBT.
+For example:
+
+```
+> set LiftModule.liftVersion := "2.6.3"
+> ++ 2.11.8
+> package
+```
+

--- a/build.sbt
+++ b/build.sbt
@@ -35,14 +35,10 @@ publishTo := (version.value.endsWith("SNAPSHOT") match {
   }
 )
 
-
-// For local deployment:
-
-credentials += Credentials( file("sonatype.credentials") )
-
-// For the build server:
-
-credentials += Credentials( file("/private/liftmodules/sonatype.credentials") )
+credentials ++= (for {
+  username <- Option(System.getenv().get("SONATYPE_USERNAME"))
+  password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
+} yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "amqp"
 
 organization := "net.liftmodules"
 
-version := "1.4.0"
+version := "1.4.0-SNAPSHOT"
 
 liftVersion := "3.0.1"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,40 +1,40 @@
+import LiftModule.{liftVersion, liftEdition}
+
 name := "amqp"
 
 organization := "net.liftmodules"
 
-version := "1.4-SNAPSHOT"
+version := "1.4.0"
 
-liftVersion <<= liftVersion ?? "3.0-RC2"
+liftVersion := "3.0.1"
 
-liftEdition <<= liftVersion apply { _.substring(0,3) }
+liftEdition := liftVersion.value.substring(0,3)
 
-moduleName <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
+moduleName := name.value + "_" + liftEdition.value
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
 
-crossScalaVersions := Seq("2.11.8", "2.10.6", "2.9.2", "2.9.1-1", "2.9.1")
+crossScalaVersions := Seq("2.12.1", "2.11.8")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
-
-resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
 
 resolvers += "Java.net Maven2 Repository" at "http://download.java.net/maven/2/"
 
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-libraryDependencies <++= liftVersion { v =>
-  "net.liftweb" %% "lift-webkit" % v % "provided" ::
-  "net.liftweb" %% "lift-actor"  % v % "provided" ::
+libraryDependencies ++=
+  "net.liftweb" %% "lift-webkit" % liftVersion.value % "provided" ::
+  "net.liftweb" %% "lift-actor"  % liftVersion.value % "provided" ::
   Nil
-}
 
 libraryDependencies += "com.rabbitmq" % "amqp-client" % "3.4.0"
 
-publishTo <<= version { _.endsWith("SNAPSHOT") match {
- 	case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
- 	case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+publishTo := (version.value.endsWith("SNAPSHOT") match {
+  case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+  case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
   }
-}
+)
+
 
 // For local deployment:
 
@@ -51,24 +51,24 @@ publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 
 pomExtra := (
-	<url>https://github.com/liftmodules/amqp</url>
-	<licenses>
-		<license>
-	      <name>Apache 2.0 License</name>
-	      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-	      <distribution>repo</distribution>
-	    </license>
-	 </licenses>
-	 <scm>
-	    <url>git@github.com:liftmodules/amqp.git</url>
-	    <connection>scm:git:git@github.com:liftmodules/amqp.git</connection>
-	 </scm>
-	 <developers>
-	    <developer>
-	      <id>liftmodules</id>
-	      <name>Lift Team</name>
-	      <url>http://www.liftmodules.net</url>
-	 	</developer>
-	 </developers>
- )
+  <url>https://github.com/liftmodules/amqp</url>
+  <licenses>
+    <license>
+      <name>Apache 2.0 License</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>git@github.com:liftmodules/amqp.git</url>
+    <connection>scm:git:git@github.com:liftmodules/amqp.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>liftmodules</id>
+      <name>Lift Team</name>
+      <url>http://www.liftmodules.net</url>
+  </developer>
+  </developers>
+)
 

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,12 +1,11 @@
 import sbt._
 import sbt.Keys._
 
-object LiftModuleBuild extends Build {
+object LiftModule {
 
-  val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
+  val liftVersion = settingKey[String]("Lift Web Framework full version number")
 
-  val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")
-
-  val project = Project("LiftModule", file("."))
-
+  val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
 }
+
+//val project = Project("LiftModule", file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.13

--- a/src/main/scala/net/liftmodules/amqp/AMQPDispatcher.scala
+++ b/src/main/scala/net/liftmodules/amqp/AMQPDispatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2010 WorldWide Conferencing, LLC
+ * Copyright 2007-2016 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ class ExampleStringAMQPListener {
     import ConnectionFactory._
 
     // thor.local is a machine on your network with rabbitmq listening on port 5672
-    setHost("thor.local")
+    setHost("localhost")
     setPort(DEFAULT_AMQP_PORT)
     setUsername(DEFAULT_USER)
     setPassword(DEFAULT_PASS)

--- a/src/main/scala/net/liftmodules/amqp/AMQPSender.scala
+++ b/src/main/scala/net/liftmodules/amqp/AMQPSender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2011 WorldWide Conferencing, LLC
+ * Copyright 2007-2016 WorldWide Conferencing, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,17 +126,15 @@ object ExampleDirectAMQPSender {
  * for me to run from script/console to see the bits flying.
  */
 object AMQPExampleFunPack {
-  def directExample {
+  def directExample: Unit = {
     val recv = new ExampleStringAMQPListener()
     // You should see the message 'hi'
     val sender = new ExampleStringAMQPSender()
-    sender
   }
-  def actorExample {
+  def actorExample: Unit = {
     val recv = new ExampleStringAMQPListener()
     // You probably know what message you are going to see. 'hello!'
     val sender = ExampleDirectAMQPSender.sendMsg("hello!")
-    sender
   }
 }
 

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+  echo "Not a pull request"
+  if [ "${TRAVIS_BRANCH}" = "feature/lift-3-scala-2.12" ]; then
+    echo "Attemping publish"
+    mkdir -p ~/.sbt/0.13/plugins/
+    sbt +publish
+  fi
+fi

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+ 
+# Automatically publish snapshots for branches pushed to master.
 
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  echo "Not a pull request"
-  if [ "${TRAVIS_BRANCH}" = "feature/lift-3-scala-2.12" ]; then
-    echo "Attemping publish"
-    mkdir -p ~/.sbt/0.13/plugins/
+if [[ "${TRAVIS_PULL_REQUEST}" == "false" &&
+      "${TRAVIS_BRANCH}" == "master" &&
+      $(cat build.sbt) =~ "-SNAPSHOT"
+]]; then
     sbt +publish
-  fi
 fi


### PR DESCRIPTION
In this PR...

- Support Lift 3.0 and Scala 2.12 (and remove deprecations)
- Update to SBT 0.13.13 (and remove deprecations)
- Add Travis build
- Added post-build publish step (credit to: https://github.com/milessabin/shapeless/blob/master/scripts/travis-publish.sh)

In theory, when this PR is merged to master, the SNAPSHOT will be published to Sonatype.

Non-snapshot builds are manual.